### PR TITLE
V0.4.1 - Cleans up sign/register errors and adds script to reset password

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn lint:app && yarn lint:server
+npm run lint

--- a/app/components/home/menu/mobile.jsx
+++ b/app/components/home/menu/mobile.jsx
@@ -1,11 +1,11 @@
 // import dependencies
 import PropTypes from 'prop-types';
+import { observer } from 'mobx-react-lite';
 
 // import local files
 import useDropdown from '../../../hooks/useDropdown';
 import { FaEllipsisVertical } from '../../icons';
 import Dropdown from '../../ui/dropdown';
-import { observer } from 'mobx-react-lite';
 import useContextStore from '../../../context';
 import MonitorConfigureModal from '../../modal/monitor/configure';
 

--- a/app/components/ui/input.scss
+++ b/app/components/ui/input.scss
@@ -34,3 +34,11 @@
   margin: pxToRem(4);
   display: block;
 }
+
+.text-input-error-general {
+  color: var(--red-700);
+  font-size: var(--font-md);
+  margin: pxToRem(4);
+  display: block;
+  text-align: center;
+}

--- a/app/handlers/login.js
+++ b/app/handlers/login.js
@@ -27,7 +27,7 @@ const handleLogin = async (inputs, setErrors, navigate) => {
     }
 
     if (error.response?.data?.message) {
-      return setErrors(error.response?.data?.message);
+      return setErrors({ general: error.response?.data?.message });
     }
 
     toast.error('Something went wrong');

--- a/app/handlers/register.js
+++ b/app/handlers/register.js
@@ -22,10 +22,7 @@ const handleRegister = async (inputs, setErrors, setPage, navigate) => {
     setPage('verify');
   } catch (error) {
     if (error?.response?.data?.message) {
-      setErrors((prev) => ({
-        ...prev,
-        ...error?.response?.data?.message,
-      }));
+      return setErrors(error?.response?.data?.message);
     }
 
     toast.error('Something went wrong!');

--- a/app/hooks/useLogin.jsx
+++ b/app/hooks/useLogin.jsx
@@ -36,7 +36,10 @@ const useLogin = () => {
   };
 
   const setErrors = (error) => {
-    return setValues((prev) => ({ ...prev, errors: error }));
+    return setValues((prev) => ({
+      ...prev,
+      errors: { ...prev.errors, ...error },
+    }));
   };
 
   return {

--- a/app/hooks/useRegister.jsx
+++ b/app/hooks/useRegister.jsx
@@ -129,7 +129,7 @@ const useRegister = () => {
   const setErrors = (errors) => {
     return setValues((prev) => ({
       ...prev,
-      errors,
+      errors: { ...prev.errors, ...errors },
     }));
   };
 

--- a/app/pages/login.jsx
+++ b/app/pages/login.jsx
@@ -22,7 +22,7 @@ const Login = () => {
         </div>
 
         {errors['general'] && (
-          <div className="text-input-error">{errors['general']}</div>
+          <div className="text-input-error-general">{errors['general']}</div>
         )}
         <div>
           <TextInput

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lunalytics",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Open source Node.js server/website monitoring tool",
   "private": true,
   "author": "KSJaay <ksjaay@gmail.com>",
@@ -18,6 +18,7 @@
     "lint:server": "eslint server --ext js",
     "prepare": "husky install",
     "preview": "vite preview",
+    "reset:password": "node ./scripts/reset.js",
     "server:watch": "nodemon --delay 2 --watch server ./server/index.js",
     "setup": "npm install && node ./scripts/setup.js && npm run build",
     "start": "cross-env NODE_ENV=production node server/index.js"

--- a/scripts/reset.js
+++ b/scripts/reset.js
@@ -1,0 +1,80 @@
+const inquirer = require('inquirer');
+const logger = require('../server/utils/logger');
+const SQLite = require('../server/database/sqlite/setup');
+const { generateHash } = require('../server/utils/hashPassword');
+
+const questions = [
+  { type: 'input', name: 'email', message: 'Enter email added: ' },
+];
+
+const generatePassword = () => {
+  const numbers = '1234567890';
+  const alphaNumeric =
+    'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890';
+  const charLength = alphaNumeric.length;
+
+  var password = '';
+
+  for (let i = 0; i < 12; ++i) {
+    password += alphaNumeric.charAt(Math.floor(Math.random() * charLength));
+  }
+
+  password += numbers.charAt(Math.floor(Math.random() * charLength));
+
+  return password;
+};
+
+inquirer
+  .prompt(questions)
+  .then(async (answers) => {
+    if (!answers?.email) {
+      logger.log(
+        'RESET PASSWORD',
+        'Please enter a valid email address.',
+        'ERROR',
+        false
+      );
+      return;
+    }
+
+    const email = answers.email.toLowerCase().trim();
+    const client = await SQLite.connect();
+
+    const emailExists = client('user').where({ email }).first();
+
+    if (!emailExists) {
+      logger.log(
+        'RESET PASSWORD',
+        'Email provided does not exist in the database.',
+        'ERROR',
+        false
+      );
+      return;
+    }
+
+    const newPassword = generatePassword();
+    const hashedPassowrd = generateHash(newPassword);
+
+    await client('user').where({ email }).update({ password: hashedPassowrd });
+
+    logger.log(
+      'RESET PASSWORD',
+      `Password has been reset to: ${newPassword}`,
+      'INFO',
+      false
+    );
+
+    await client.destroy();
+    process.exit(1);
+  })
+  .catch((error) => {
+    logger.log('', error, 'ERROR', false);
+    logger.log(
+      'RESET PASSWORD',
+      'Error resetting password, please try again.',
+      'ERROR',
+      false
+    );
+
+    process.exit(1);
+  });


### PR DESCRIPTION
Pretty quick update, adds a new script to reset a user's password based on email. Currently, it's a command but may look into sending emails to the user instead in the future.

## Update
- Register page now shows errors when email, username, or password formats are incorrect
- Register page now shows an error if the email is already registered
- Signin page now shows errors when email, or password formats are incorrect
- Signin page now shows errors when email doesn't exist
- Signin page now shows errors when email exists but password is incorrect

## Features
- A user's password can now be reset using `npm run reset:password`