### PR TITLE
v0.4.4 - Adds middleware for demo mode and kanban endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /app/components/icons/list.jsx
 docs/.vitepress/dist
 docs/.vitepress/cache
+public/kanban.json
 
 # misc
 .DS_Store

--- a/app/components/settings/manage/index.jsx
+++ b/app/components/settings/manage/index.jsx
@@ -39,7 +39,7 @@ const ManageTeam = () => {
         padding: '10px 20px',
       }}
     >
-      <div style={{ display: 'flex' }}>
+      <div style={{ display: 'flex', overflow: 'auto' }}>
         <MembersTable members={sortedMembers} />
       </div>
     </div>

--- a/scripts/loadEnv.js
+++ b/scripts/loadEnv.js
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'fs';
 import path from 'path';
 import logger from '../server/utils/logger.js';
 
-const configPath = path.join(process.cwd(),  'config.json');
+const configPath = path.join(process.cwd(), 'config.json');
 
 if (!existsSync(configPath)) {
   logger.log(
@@ -18,5 +18,6 @@ const config = JSON.parse(readFileSync(configPath, 'utf-8'));
 process.env.VITE_REACT_APP_VERSION = config.version;
 process.env.PORT = config.port;
 process.env.JWT_SECRET = config.jwtSecret;
+process.env.IS_DEMO = config.isDemo;
 
 logger.log('SETUP', 'Environment variables loaded successfully.', 'INFO');

--- a/server/database/queries/user.js
+++ b/server/database/queries/user.js
@@ -97,6 +97,23 @@ const updateUserPermission = (email, permission) => {
   return SQLite.client('user').where({ email }).update({ permission });
 };
 
+const getDemoUser = async () => {
+  const demoUser = await SQLite.client('user').where({ email: 'demo' }).first();
+
+  if (!demoUser) {
+    await SQLite.client('user').insert({
+      email: 'demo',
+      displayName: 'Demo User',
+      password: 'demo',
+      avatar: null,
+      permission: 4,
+      isVerified: true,
+    });
+  }
+
+  return signCookie({ email: 'demo' });
+};
+
 export {
   signInUser,
   registerUser,
@@ -108,4 +125,5 @@ export {
   declineAccess,
   approveAccess,
   updateUserPermission,
+  getDemoUser,
 };

--- a/server/index.js
+++ b/server/index.js
@@ -14,6 +14,7 @@ import SQLite from './database/sqlite/setup.js';
 import initialiseCronJobs from './utils/cron.js';
 import authorization from './middleware/authorization.js';
 import migrateDatabase from '../scripts/migrate.js';
+import isDemo from './middleware/demo.js';
 
 const app = express();
 
@@ -47,6 +48,11 @@ const init = async () => {
     return res.status(200).send('Everything looks good :D');
   });
 
+  app.get('/api/kanban', (req, res) => {
+    return res.sendFile(path.join(process.cwd(), '/public/kanban.json'));
+  });
+
+  app.use(isDemo);
   app.use(authorization);
   logger.info('Express', 'Initialising routes');
   initialiseRoutes(app);

--- a/server/middleware/demo.js
+++ b/server/middleware/demo.js
@@ -1,0 +1,15 @@
+import { getDemoUser } from '../database/queries/user.js';
+import { setServerSideCookie } from '../utils/cookies.js';
+
+const isDemo = async (request, response, next) => {
+  if (process.env.IS_DEMO) {
+    const cookie = await getDemoUser();
+
+    setServerSideCookie(response, 'access_token', cookie);
+    request.cookies['access_token'] = cookie;
+  }
+
+  return next();
+};
+
+export default isDemo;


### PR DESCRIPTION
I wanted to create a demo mode on the website that allows the user to log on without needing to create an account and be verified. Demo mode account has `viewer` permissions and is not able to edit any of the current information on the page. Along with that, I've also added a kanban endpoint for the docs, this isn't a fully customisable kanban endpoint but will still allow me to make it dynamic.