### PR TITLE
0.7.1 - Fixes issues with migration scripts not working for 0.6.5 and 0.7.0

### DIFF
--- a/docs/internals/changelog.md
+++ b/docs/internals/changelog.md
@@ -1,5 +1,13 @@
 # Previous updates
 
+## 0.7.1
+
+### Fixes issues with migration scripts not working for 0.6.5 and 0.7.0
+
+### Summary
+
+While migrating from 0.6.0 to 0.7.0, I noticed that the migration scripts weren't working for both of 0.6.5 and 0.7.0. This update fixes the scripts so they work for both versions. Will be running more tests on migration scripts in the future to make sure this doesn't happen again.
+
 ## 0.7.0
 
 ### Adds support for PostgreSQL and new setup system

--- a/scripts/migrations/cache-0-6-5.js
+++ b/scripts/migrations/cache-0-6-5.js
@@ -14,7 +14,7 @@ const migrate = async () => {
   const client = await SQLite.connect();
 
   await client.schema.alterTable('certificate', (table) => {
-    table.timestamp('nextCheck').defaultTo(client.fn.now());
+    table.timestamp('nextCheck');
   });
 
   logger.info('Migrations', { message: '0.6.5 has been applied' });

--- a/scripts/migrations/postgres-0-7-0.js
+++ b/scripts/migrations/postgres-0-7-0.js
@@ -69,14 +69,13 @@ const migrate = async () => {
   logger.info('Heartbeats - Converting createdAt to datetime...');
   await client.schema.alterTable('heartbeat', (table) => {
     table.datetime('date');
-    table.index(['monitorId', 'date']);
   });
 
   logger.info('Heartbeats - Updating createdAt...');
   for (const heartbeat of heartbeats) {
     const date = new Date(heartbeat.date).toISOString();
     await SQLite.client('heartbeat')
-      .where({ monitorId: heartbeat.monitorId })
+      .where({ id: heartbeat.id })
       .update({ date });
   }
 
@@ -92,14 +91,13 @@ const migrate = async () => {
   logger.info('Hourly Heartbeats - Converting date to datetime...');
   await client.schema.alterTable('hourly_heartbeat', (table) => {
     table.datetime('date');
-    table.index(['monitorId', 'date']);
   });
 
   logger.info('Hourly Heartbeats - Updating date...');
   for (const heartbeat of hourlyHeartbeats) {
     const date = new Date(heartbeat.date).toISOString();
     await SQLite.client('hourly_heartbeat')
-      .where({ monitorId: heartbeat.monitorId })
+      .where({ id: heartbeat.id })
       .update({ date });
   }
 

--- a/server/database/sqlite/setup.js
+++ b/server/database/sqlite/setup.js
@@ -91,7 +91,7 @@ export class SQLite {
         table.string('avatar');
         table.boolean('isVerified').defaultTo(0);
         table.integer('permission').defaultTo(4);
-        table.datetime('createdAt').defaultTo(this.client.fn.now());
+        table.datetime('createdAt');
 
         table.index('email');
         table.index('isVerified');
@@ -138,7 +138,7 @@ export class SQLite {
         table.text('content').defaultTo(null);
         table.string('friendlyName');
         table.text('data');
-        table.datetime('createdAt').defaultTo(this.client.fn.now());
+        table.datetime('createdAt');
 
         table.index('id');
       });
@@ -211,7 +211,7 @@ export class SQLite {
         table.datetime('validTill');
         table.text('validOn');
         table.integer('daysRemaining').defaultTo(0);
-        table.datetime('nextCheck').defaultTo(this.client.fn.now());
+        table.datetime('nextCheck');
 
         table.index('monitorId');
       });


### PR DESCRIPTION
## Summary
While migrating from 0.6.0 to 0.7.0, I noticed that the migration scripts weren't working for both of 0.6.5 and 0.7.0. This update fixes the scripts so they work for both versions. Will be running more tests on migration scripts in the future to make sure this doesn't happen again.