### PR TITLE
fix: improve setup flow and handle missing configuration gracefully

### DIFF
--- a/app/services/axios.js
+++ b/app/services/axios.js
@@ -1,5 +1,16 @@
 import axios from 'axios';
 
+axios.interceptors.response.use(
+  function(response) {
+    if (response.headers['content-type']?.includes('application/json')) {
+        if (response.data?.setupRequired	=== true && window.location.pathname !== '/setup') {
+          window.location.href = '/setup';
+        }
+    }
+    return response;
+  }
+);
+
 const createURL = (path, params) => {
   if (!path) return path;
   if (path?.startsWith('http')) return new URL(path);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dev:prepare": "husky",
     "preview": "vite preview",
     "reset:password": "node ./scripts/reset.js",
-    "server:watch": "nodemon --delay 2 --watch server --watch shared ./server/index.js",
+    "server:watch": "nodemon --inspect --delay 2 --watch server --watch shared ./server/index.js",
     "setup": "npm install && node ./scripts/setup.js && npm run build",
     "start": "cross-env NODE_ENV=production node server/index.js",
     "docs:dev": "vitepress dev docs",

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -20,6 +20,10 @@ if (configExists()) {
 
 try {
   logger.info('SETUP', { message: 'Creating config file...' });
+  // create data directory if it does not exist
+  if (!fs.existsSync(path.join(process.cwd(), 'data'))) {
+    fs.mkdirSync(path.join(process.cwd(), 'data'));
+  }
 
   // create config.json file
   const configPath = path.join(process.cwd(), 'data', 'config.json');

--- a/server/middleware/auth/setup.js
+++ b/server/middleware/auth/setup.js
@@ -18,6 +18,30 @@ import { parseUserAgent } from '../../utils/uaParser.js';
 
 const packageJson = loadJSON('package.json');
 
+/**
+ * Creates the data directory if it does not exist.
+ *
+ * The data directory is where things like the SQLite database and
+ * uploaded certificates are stored.
+ */
+const createDataDirIfNotExist = () => {
+  if (!fs.existsSync(path.join(process.cwd(), 'data'))) {
+    fs.mkdirSync(path.join(process.cwd(), 'data'));
+  }
+};
+
+/**
+ * Writes the config to the `config.json` file in the `data` directory.
+ *
+ * @param {Object} config - The config object to write to the file.
+ */
+const writeConfigFile = (config) => {
+  fs.writeFileSync(
+    path.join(process.cwd(), 'data', 'config.json'),
+    JSON.stringify(config, null, 2)
+  );
+};
+
 const createBasicSetup = ({
   databaseType,
   databaseName,
@@ -36,10 +60,8 @@ const createBasicSetup = ({
     retentionPeriod,
   };
 
-  fs.writeFileSync(
-    path.join(process.cwd(), 'data', 'config.json'),
-    JSON.stringify(config, null, 2)
-  );
+  createDataDirIfNotExist();
+  writeConfigFile(config);
 
   logger.info('SETUP', { message: 'Config file created successfully' });
 };
@@ -75,10 +97,8 @@ const createAdvancedSetup = ({
     };
   }
 
-  fs.writeFileSync(
-    path.join(process.cwd(), 'data', 'config.json'),
-    JSON.stringify(config, null, 2)
-  );
+  createDataDirIfNotExist();
+  writeConfigFile();
 
   logger.info('SETUP', { message: 'Config file created successfully' });
 };

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -6,6 +6,10 @@ class Config {
     this.configPath = `${process.cwd()}/data/config.json`;
     this.config = {};
 
+    if (!fs.existsSync(this.configPath)) {
+      return;
+    }
+
     try {
       fs.watch(this.configPath, { persistent: false }, (eventType) => {
         if (eventType === 'change') {
@@ -25,14 +29,6 @@ class Config {
   }
 
   readConfigFile() {
-    if (!fs.existsSync(this.configPath)) {
-      logger.error('CONFIG', {
-        message:
-          'Configuration file not found. Please run "npm run setup" (or "yarn setup" or "pnpm setup") to create it.',
-      });
-      return;
-    }
-
     const fileData = fs.readFileSync(this.configPath);
 
     try {
@@ -60,8 +56,7 @@ class Config {
   }
 
   get(key) {
-    const value = this.config[key];
-    return value;
+    return Object.keys(this.config).includes(key) ? this.config[key] : null;
   }
 }
 


### PR DESCRIPTION
## Summary
I tried to set up the app both with Docker and directly running `npm run setup` but failed. 
First, a redirect loop to setup page happened and second, there was an error in the console:
```
> lunalytics@0.8.3 start
> cross-env NODE_ENV=production node server/index.js

error: CONFIG ENOENT: no such file or directory, watch '/home/stz184/services/lunalytics/data/config.json' {"service":"bot","stack":"Error: ENOENT: no such file or directory, watch '/home/stz184/services/lunalytics/data/config.json'\n    at FSWatcher.<computed> (node:internal/fs/watchers:247:19)\n    at Object.watch (node:fs:2551:36)\n    at new Config (file:///home/stz184/services/lunalytics/server/utils/config.js:10:10)\n    at file:///home/stz184/services/lunalytics/server/utils/config.js:68:16\n    at ModuleJob.run (node:internal/modules/esm/module_job:274:25)\n    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:644:26)\n    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:98:5)","timestamp":1744487086032}
error: CONFIG Configuration file not found. Please run "npm run setup" (or "yarn setup" or "pnpm setup") to create it. {"service":"bot","timestamp":1744487086082}
error: SQLITE Database name is not set in config.json {"service":"bot","timestamp":1744487086330}
notice: Express Initialising routes {"service":"bot","timestamp":1744487086971}
notice: Express Serving production static files {"service":"bot","timestamp":1744487086983}
notice: Express Serving production static files {"service":"bot","timestamp":1744487086992}
notice: Express Server is running on port 2308 {"service":"bot","timestamp":1744487087119}
```


## New Features
- Update package.json to include debug flag for server watch

## Updates
This commit modifies the setup process to:
- Create data directory automatically if missing
- Handle missing configuration files more gracefully: now, no matter if you run the dev version (`npm run dev`) or production build (`npm run start`), the behavior is the same: if there is no configuration file, the middleware will detect it and it will send a proper JSON response to the frontend to instruct it to redirect to `/setup` route.
The previous logic was incorrect because of few reasons:
1. It creates a redirect loop, because line 25 of `setupExists.js` redirects to `/login` and once you land on `login`, the middleware kicks again and redirects you back to `/setup`. 
2. If you run the dev server, you can't redirect the react app to  `/setup` route with 301 response from the backend fetch calls. 
3. If there is invalid configuration (missing keys from the JSON config), unexpected redirects may happen.
- Move setup check logic to frontend with proper API responses to prevent possible redirection loops
- Add axios interceptor to detect setup requirements - central place where all backend calls are tracked
- Improve middleware to avoid redirect loops
