### PR TITLE
Negative ChatID is now allowed

### DIFF
--- a/shared/validators/notifications/telegram.js
+++ b/shared/validators/notifications/telegram.js
@@ -7,7 +7,7 @@
 
 import { NotificationValidatorError } from '../../utils/errors.js';
 
-const chatIdRegex = /^[0-9]+$/;
+const chatIdRegex = /^-?[0-9]+$/;
 const friendlyNameRegex = /^[a-zA-Z0-9_-]+$/;
 const messageTypes = ['basic', 'pretty', 'nerdy'];
 const tokenRegex = /^[0-9]+:[a-zA-Z0-9_-]{1,35}$/;


### PR DESCRIPTION
## Summary
Telegram has negative chatID sometimes, which regExp does not allow.

## New Features
Negative chatID is now allowed, negativity is optional

## Updates
No further updates

## Additional Info
![image](https://github.com/user-attachments/assets/0549b76d-1238-4cc5-9453-b4c2fada78fb)


- [-] Does this update require migration? (If yes, add extra details)
- [-] Are there any other PRs that need to be merged? (If yes, add extra details)
