### PR TITLE
A failed Create call now switches to the page with an error

### DIFF
--- a/app/components/modal/monitor/configure.tsx
+++ b/app/components/modal/monitor/configure.tsx
@@ -43,11 +43,12 @@ const MonitorConfigureModal = ({
   isEdit = false,
 }: ModalProps) => {
   const [pageId, setPageId] = useState('basic');
-  const { errors, inputs, handleActionButtons, handleInput } = useMonitorForm(
+  const { errors, inputs, handleActionButtons, handleInput, errorPages, setErrorPages } = useMonitorForm(
     monitor,
     isEdit,
     closeModal,
-    handleMonitorSubmit
+    handleMonitorSubmit,
+    setPageId
   );
 
   return (
@@ -65,12 +66,19 @@ const MonitorConfigureModal = ({
           <div className="monitor-configure-left-pages">
             {pages.map((page) => (
               <div
-                className={
-                  page.id === pageId
-                    ? 'monitor-configure-page-button active'
-                    : 'monitor-configure-page-button'
-                }
-                onClick={() => setPageId(page.id)}
+                className={`monitor-configure-page-button 
+                  ${page.id === pageId ? 'active' : ''}
+                  ${errorPages.has(page.id) ? 'error-circle' : ''}`}
+
+                onClick={() => {
+                  setErrorPages(oldSet => {
+                    const trimmedErrorPages = new Set([...oldSet])
+                    trimmedErrorPages.delete(pageId)
+                    return trimmedErrorPages
+                  })
+                  setPageId(page.id)
+                  
+                }}
                 key={page.id}
               >
                 {page.icon}

--- a/app/components/modal/monitor/styles.scss
+++ b/app/components/modal/monitor/styles.scss
@@ -13,6 +13,7 @@
 }
 
 .monitor-configure-page-button {
+  position: relative;
   padding: 12px;
   background-color: var(--accent-800);
   border-radius: 8px;
@@ -30,6 +31,17 @@
 
   &:hover {
     background-color: var(--accent-700);
+  }
+  
+  &.error-circle::after {
+    content: "";
+    position: absolute;
+    top: 40%;
+    right: 10px; 
+    width: 10px; 
+    height: 10px;
+    background-color: red;
+    border-radius: 50%;
   }
 }
 


### PR DESCRIPTION

![lunaGif](https://github.com/user-attachments/assets/51075c80-1b60-473a-bc8e-5c8fba03ba20)


## Summary
If you selected "Create" when making a new monitor, unless you were on the page with the error it was unclear what went wrong. Now it switches to a page with an error on it and every page that has an error is marked with a red dot.
  
## New Features
- Not really a feature just an update
## Updates

### .../hooks/useMonitorForm.tsx
- Within the `useMonitorForm.tsx` file I created a helper function `getPagesWithErrors` that returns a set with pages that have errors
- This set is used in `useMonitorForm` to `setPageId` which I passed from it's parent `configure.tsx` 
    - This allows it to set the page to one with an error.

### .../monitor/configure.tsx
- That same set of error pages is then returned to `configure.tsx` where it is used to add the `error-circle` class to any page with an error
- The `onClick` event handler for each page was updated to also remove the previous error page from the error set (which subsequently removes the red dot.)
    - When you click to a new page the red dot is removed from the previous page

### .../monitor/styles.scss
- `error-circle` was added to `styles.scss` and styled to create a red dot


## Additional Info

I'm not 100% convinced that it's necessary to remove the red dot when clicking away from a page with an error. At the moment the error messages that are associated with each input will stay until you "Submit" again. But this way if there are multiple pages that have an error, it is clear which pages you've already been to. 
(If you prefer to keep the red dots visible until a new Submit, it just requires the `onClick` logic in `configure.tsx` to be removed.)

Ideally I think the most informative way to handle errors on the forms would be to validate each separately `onBlur` so the user has instant feedback. But that would be a fairly involved overhaul of the entire system. So I offer this as an option to make any errors more clear to the user. 



- [No ] Does this update require migration? (If yes, add extra details)
- [No ] Are there any other PRs that need to be merged? (If yes, add extra details)
