### PR TITLE
0.10.15 - Updates status to show degraded when monitor is down

### DIFF
--- a/app/components/status/configure/preview/header/index.tsx
+++ b/app/components/status/configure/preview/header/index.tsx
@@ -13,6 +13,7 @@ const StatusPageHeader = ({
   homepageUrl = '/',
   logo = '/logo.svg',
   titleText = 'Lunalytics',
+  lastUpdated = new Date().toISOString(),
 }) => {
   const orders = useMemo(() => {
     const positions = [];
@@ -57,7 +58,7 @@ const StatusPageHeader = ({
         logo={logo}
         titleText={titleText}
       />
-      <StatusPageHeaderStatus status={status} />
+      <StatusPageHeaderStatus status={status} lastUpdated={lastUpdated} />
 
       {orders.map((order, index) => (
         <div key={index} style={{ order: order }}></div>

--- a/app/components/status/configure/preview/header/status.tsx
+++ b/app/components/status/configure/preview/header/status.tsx
@@ -2,7 +2,7 @@
 import dayjs from 'dayjs';
 import classNames from 'classnames';
 
-const StatusPageHeaderStatus = ({ status = {} }) => {
+const StatusPageHeaderStatus = ({ status = {}, lastUpdated }) => {
   if (!status.showLogo && !status.showTitle) {
     return null;
   }
@@ -25,7 +25,7 @@ const StatusPageHeaderStatus = ({ status = {} }) => {
       {status.showStatus && <div className={titleClasses}>Service Status</div>}
       {status.showTitle && (
         <div className={subtitleClasses}>
-          Last check: {dayjs().format('HH:mm:ss')}
+          Last check: {dayjs(lastUpdated).format('HH:mm:ss')}
         </div>
       )}
     </a>

--- a/app/components/status/configure/preview/incident.tsx
+++ b/app/components/status/configure/preview/incident.tsx
@@ -1,3 +1,5 @@
+import '../layout/incidents/styles.scss';
+
 // import local files
 import StatusIncidentBasic from '../layout/incidents/design/basic';
 import StatusIncidentPretty from '../layout/incidents/design/pretty';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lunalytics",
-  "version": "0.10.13",
+  "version": "0.10.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lunalytics",
-      "version": "0.10.13",
+      "version": "0.10.14",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",

--- a/server/class/monitor/statusPage.js
+++ b/server/class/monitor/statusPage.js
@@ -7,4 +7,5 @@ export const cleanMonitorForStatusPage = (monitor) => ({
   createdAt: monitor.createdAt,
   paused: monitor.paused == '1',
   icon: parseJsonOrArray(monitor.icon),
+  isDown: monitor.isDown ?? false,
 });

--- a/server/class/status.js
+++ b/server/class/status.js
@@ -16,6 +16,7 @@ export const cleanStatusPage = (status) => ({
   layout: parseJson(status.layout, true),
   email: status.email,
   createdAt: status.createdAt,
+  lastUpdated: status.lastUpdated,
 });
 
 export const cleanStatusPageWithMonitors = (status) => ({
@@ -32,4 +33,5 @@ export const cleanStatusApiResponse = (data) => ({
   monitors: data.monitors,
   incidents: data.incidents,
   heartbeats: data.heartbeats,
+  lastUpdated: data.lastUpdated,
 });


### PR DESCRIPTION
## Summary
Something that I was meant to do a while ago but never got around to doing, it now shows "degraded" when a monitor is down instead of waiting for the user to create an incident. 

## Updates
- Updates status to show degraded when monitor is down
- Updates the `last update` date to the last time monitor was fetched
- Fixes a few css bug with the layout for incident on status pages